### PR TITLE
feat: add shell configuration and select-only mode 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/muesli/termenv v0.16.0
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.15.0 // indirect


### PR DESCRIPTION
  - Add config-based shell override to fix incorrect $SHELL detection (fixes fish/custom shell issues) 
  - Add --select-only (-s) flag to output path for shell integration 
  - Implement proper color support when outputting to stderr - Refactor duplicate shell detection code into getShell() function 
  - Update onboarding to include optional shell configuration    
  - Migrate config from plain text to JSON format (backward compatible) 
  - Document shell integration with examples for bash/zsh/fish

  This allows users to either: 
1. Use default subprocess mode for
  isolated experiments 
2. Use select-only mode with `cd $(try -s)` for
  current shell navigation

Closes #1 